### PR TITLE
Fix filename generation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const {promisify} = require('util')
 const {extname, join} = require('path')
 const {createWriteStream, mkdir} = require('fs')
+const url = require('url')
 const execa = require('execa')
 const hasha = require('hasha')
 const getStream = require('get-stream')
@@ -146,8 +147,17 @@ function extractContentType(response) {
 }
 
 function getFileNameFromLocation(location) {
-  const pos = location.lastIndexOf('/')
-  return pos < location.length ? location.substr(pos + 1) : null
+  const {pathname} = url.parse(location)
+
+  if (!pathname) {
+    return null
+  }
+
+  return pathname
+    .split('/')
+    .pop()
+    .split('#')[0]
+    .split('?')[0] || null
 }
 
 function getExtension(fileName) {


### PR DESCRIPTION
`http://foo.com?sdf` would return `'?sdf'` as a filename. It now returns `null`.
`http://foo.com` would return `foo.com` as a filename. It now returns `null`.