### PR TITLE
Stop trying to remove query string & hash from pathname

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,11 +153,7 @@ function getFileNameFromLocation(location) {
     return null
   }
 
-  return pathname
-    .split('/')
-    .pop()
-    .split('#')[0]
-    .split('?')[0] || null
+  return pathname.split('/').pop() || null
 }
 
 function getExtension(fileName) {


### PR DESCRIPTION
The pathname will never contain a query string nor a hash.