### PR TITLE
Fix first chunk retrieval

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ const {createTempDirectory} = require('./util/tmpdir')
 const {analyzeLocation} = require('./directory')
 
 const mkdirAsync = promisify(mkdir)
+const firstChunkTimeout = 10000
 
 async function analyzeURL(location) {
   debug('fetching %s', location)
@@ -92,7 +93,7 @@ async function analyzeURL(location) {
     return result
   }
 
-  result.fileType = detectFileType(response)
+  result.fileType = await detectFileType(response)
 
   if (isArchive(result.fileType)) {
     let tmpDirectory
@@ -165,8 +166,9 @@ function getExtension(fileName) {
   return extname(fileName).substr(1).toLowerCase()
 }
 
-function detectFileType(response) {
-  return whichType(getFirstChunk(response)) || {}
+async function detectFileType(response) {
+  const firstChunk = await getFirstChunk(response)
+  return whichType(firstChunk) || {}
 }
 
 function isHTML(response) {
@@ -209,10 +211,17 @@ function isArchive(fileType) {
 }
 
 function getFirstChunk(response) {
-  const firstChunk = response.body.read()
-  if (!firstChunk) throw new Error('No chunk available')
-  response.body.unshift(firstChunk)
-  return firstChunk
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('Timeout when trying to get first chunk')),
+      firstChunkTimeout
+    )
+    response.body.once('data', firstChunk => {
+      clearTimeout(timeout)
+      response.body.unshift(firstChunk)
+      resolve(firstChunk)
+    })
+  })
 }
 
 function getDigestString(digest, algorithm = 'sha384') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,6 +217,7 @@ function getFirstChunk(response) {
       firstChunkTimeout
     )
     response.body.once('data', firstChunk => {
+      response.body.pause()
       clearTimeout(timeout)
       response.body.unshift(firstChunk)
       resolve(firstChunk)


### PR DESCRIPTION
Sometimes HTTP response doesn't include enough data to emit a readable chunk.
This fix transform `getFirstChunk()` into a `async function` and ensure the first chunk is effectively retrieved.
If it takes more than 10 seconds, it throw an error.