### PR TITLE
Add simple url cache

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -19,7 +19,9 @@ const analyze = {
     /Listing of/
   ],
   logger: defaultLogger,
-  concurrency: cpus().length
+  concurrency: cpus().length,
+
+  cache: null
 }
 
 const extract = {

--- a/lib/url/fetch.js
+++ b/lib/url/fetch.js
@@ -3,6 +3,21 @@
 const {hasBody} = require('type-is')
 const request = require('../util/request')
 
+const gzipSuffix = '-gzip"'
+function generateIfNoneMatch(etag) {
+  const etags = [etag]
+
+  // When Accepting gzip, some servers (apache) configuration send an
+  // Etag suffixed with -gzip. Though it doesn’t seem to be handling
+  // the -gzip Etag correctly. So we’re passing the original Etag along
+  // as well.
+  if (etag.endsWith(gzipSuffix)) {
+    etags.push(etag.slice(0, -gzipSuffix.length) + '"')
+  }
+
+  return etags.join(',')
+}
+
 async function fetch(token, options) {
   const headers = {
     'User-Agent': options.userAgent
@@ -13,7 +28,7 @@ async function fetch(token, options) {
   }
 
   if (options.etag) {
-    headers['If-None-Match'] = options.etag
+    headers['If-None-Match'] = generateIfNoneMatch(options.etag)
   }
 
   const response = await request(token.url, headers, options.timeout.connection)
@@ -31,7 +46,7 @@ async function fetch(token, options) {
     case 200:
       if (hasBody(response)) {
         token.response = response
-        break
+        return
       }
 
       throw new Error('There was no body in the response')
@@ -44,6 +59,8 @@ async function fetch(token, options) {
     default:
       throw new Error(`An invalid HTTP code was returned: ${statusCode}`)
   }
+
+  response.destroy()
 }
 
 module.exports = fetch

--- a/lib/url/index.js
+++ b/lib/url/index.js
@@ -15,10 +15,18 @@ async function analyzeUrl(token, options) {
     return false
   }
 
+  let override
+  if (options.cache && options.cache.getUrlCache) {
+    override = await options.cache.getUrlCache(token)
+  }
+
   options.logger.log('url:analyze:start', token)
 
   try {
-    await fetch(token, options)
+    await fetch(token, {
+      ...options,
+      ...override
+    })
 
     if (token.response) {
       await analyzeName(token, options)
@@ -28,6 +36,10 @@ async function analyzeUrl(token, options) {
       await analyzeAtom(token, options)
 
       await analyzeFile(token, options)
+
+      if (options.cache && options.cache.setUrlCache) {
+        await options.cache.setUrlCache(token)
+      }
     }
   } catch (err) {
     throw err

--- a/tests/url/fetch.test.js
+++ b/tests/url/fetch.test.js
@@ -77,6 +77,16 @@ test('should set if-none-match when passing an etag', async t => {
   t.is(token.response.req.getHeader('if-none-match'), etag)
 })
 
+test('should request both etags when passing an etag with a -gzip prefix', async t => {
+  const location = await serveFile(path.resolve(__dirname, '../__fixtures__/file.txt'))
+  const token = {url: location}
+  const etag = '"cool-etag-gzip"'
+
+  await fetch(token, Object.assign({etag}, options))
+
+  t.is(token.response.req.getHeader('if-none-match'), '"cool-etag-gzip","cool-etag"')
+})
+
 test('should error if request has no body', async t => {
   const location = await serveEmpty()
   const token = {url: location}

--- a/tests/url/index.test.js
+++ b/tests/url/index.test.js
@@ -67,3 +67,39 @@ test('should analyze an index-of completely', async t => {
 
   return rm(temporary)
 })
+
+test('should allow overriding fetch options with cache.getUrlCache', async t => {
+  const url = await serveFile(path.resolve(__dirname, '../__fixtures__/file.txt'))
+
+  const token = {url}
+
+  await analyzeUrl(token, Object.assign({}, options, {
+    cache: {
+      getUrlCache: token => {
+        token.hacked = true
+      }
+    }
+  }))
+
+  t.true(token.hacked)
+
+  return rm(token.temporary)
+})
+
+test('should call cache.settUrlCache to save url token data for caching purposes', async t => {
+  const url = await serveFile(path.resolve(__dirname, '../__fixtures__/file.txt'))
+
+  const token = {url}
+
+  await analyzeUrl(token, Object.assign({}, options, {
+    cache: {
+      setUrlCache: token => {
+        token.hacked = true
+      }
+    }
+  }))
+
+  t.true(token.hacked)
+
+  return rm(token.temporary)
+})


### PR DESCRIPTION
Also add a 'hack' to query "foo-gzip" an "foo" etags when we’re dealing with apache that sends "-gzip" etags but can’t match them back.

Also destroy paused non-200 responses.