### PR TITLE
Stop removing trailing slashes in index-of URLs

### DIFF
--- a/lib/url/analyzers/index-of.js
+++ b/lib/url/analyzers/index-of.js
@@ -14,7 +14,8 @@ function stripQuery(location) {
   parsed.search = ''
 
   return normalize(parsed.toString(), {
-    stripWWW: false
+    stripWWW: false,
+    removeTrailingSlash: false
   })
 }
 


### PR DESCRIPTION
This fixes an issue with some urls requiring the trailing slash.