### PR TITLE
Return exact lastModified date from response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For example, analyzing `http://example.org/index.html` would yield something lik
 | option          | default value | type    | description |
 |-----------------|---------------|---------|----------|
 | etag            | `null`        | String  | Will be set to the `If-None-Match` HTTP header |
-| lastCheckedAt   | `null`        | Date    | Date of `location`’s previous check, will be set to the `If-Modified-Since` HTTP header |
+| lastModified    | `null`        | String|Date | Date of `location`’s last modification date, will be set to the `If-Modified-Since` HTTP header |
 | userAgent       | plunger/1.0   | String  | User agent, will be set to the `User-Agent` HTTP header |
 | timeout         | `{connection: 2000, activity: 4000, download: 0}` | Object | See timeouts section |
 | cache           | `null` | Object | See caching section |
@@ -131,7 +131,7 @@ All timeouts can be disabled by setting them to 0.
 
 It is possible to pass a callback to retrieve informations about previous URL checks in order to allow unnecessary downloads. This is done using `cache.getUrlCache(token)` and `cache.setUrlCache(token)` options of `analyzeLocation()`.
 
-`cache.getUrlCache` will return an object of options that will override the options passed to `analyzeLocation()`. It can be interesting to set a `lastCheckedAt` and an `etag` property.
+`cache.getUrlCache` will return an object of options that will override the options passed to `analyzeLocation()`. It can be interesting to set a `lastModified` and an `etag` property.
 
 The idea is to save information about an analyzed URL in `cache.setUrlCache` in a custom cache.
 
@@ -142,7 +142,7 @@ async function getUrlCache(token) {
   console.log(cache ? 'HIT' : 'MISS', token.url)
   return {
     etag: cache.etag,
-    lastCheckedAt: cache.createdAt
+    lastModified: cache.lastModified
   }
 }
 ```
@@ -154,7 +154,8 @@ async function setUrlCache(token) {
   for (const url of urls) {
     await db.create({
       url,
-      etag: token.etag
+      etag: token.etag,
+      lastModified: token.lastModified
     })
     console.log('SAVE', url)
   }

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,7 +3,7 @@ const defaultLogger = require('./logger')
 
 const analyze = {
   etag: null,
-  lastCheckedAt: null,
+  lastModified: null,
   userAgent: 'plunger/1.0',
   timeout: {
     connection: 2000,

--- a/lib/url/fetch.js
+++ b/lib/url/fetch.js
@@ -23,8 +23,12 @@ async function fetch(token, options) {
     'User-Agent': options.userAgent
   }
 
-  if (options.lastCheckedAt instanceof Date && isFinite(options.lastCheckedAt)) {
-    headers['If-Modified-Since'] = options.lastCheckedAt.toUTCString()
+  if (options.lastModified) {
+    if (options.lastModified instanceof Date && isFinite(options.lastModified)) {
+      headers['If-Modified-Since'] = options.lastModified.toUTCString()
+    } else {
+      headers['If-Modified-Since'] = options.lastModified
+    }
   }
 
   if (options.etag) {
@@ -40,6 +44,11 @@ async function fetch(token, options) {
 
   if (response.headers.etag) {
     token.etag = response.headers.etag
+  }
+
+  const lastModified = response.headers['last-modified']
+  if (lastModified) {
+    token.lastModified = lastModified
   }
 
   switch (response.statusCode) {

--- a/tests/analyze.test.js
+++ b/tests/analyze.test.js
@@ -108,6 +108,7 @@ test('should analyze an empty index-of completely', async t => {
   t.deepEqual(token, {
     analyzed: true,
     etag: token.etag,
+    lastModified: token.lastModified,
     children: [],
     fileTypes: [{
       ext: 'html',

--- a/tests/url/fetch.test.js
+++ b/tests/url/fetch.test.js
@@ -59,14 +59,24 @@ test('should the user agent passed in the options', async t => {
   t.is(token.response.req.getHeader('user-agent'), options.userAgent)
 })
 
-test('should set if-modified-since when passing a lastCheckedAt date', async t => {
+test('should set if-modified-since when passing a lastModified string', async t => {
   const location = await serveFile(path.resolve(__dirname, '../__fixtures__/file.txt'))
   const token = {url: location}
-  const lastCheckedAt = new Date(2017, 4, 2)
+  const lastModified = 'Mon, 01 May 2017 22:00:00 GMT'
 
-  await fetch(token, Object.assign({lastCheckedAt}, options))
+  await fetch(token, Object.assign({lastModified}, options))
 
-  t.is(token.response.req.getHeader('if-modified-since'), lastCheckedAt.toUTCString())
+  t.is(token.response.req.getHeader('if-modified-since'), lastModified)
+})
+
+test('should set if-modified-since when passing a lastModified date', async t => {
+  const location = await serveFile(path.resolve(__dirname, '../__fixtures__/file.txt'))
+  const token = {url: location}
+  const lastModified = new Date(2017, 4, 2)
+
+  await fetch(token, Object.assign({lastModified}, options))
+
+  t.is(token.response.req.getHeader('if-modified-since'), lastModified.toUTCString())
 })
 
 test('should set if-none-match when passing an etag', async t => {

--- a/tests/url/index.test.js
+++ b/tests/url/index.test.js
@@ -53,6 +53,7 @@ test('should analyze an index-of completely', async t => {
       }
     ],
     etag: token.etag,
+    lastModified: token.lastModified,
     fileTypes: [{
       ext: 'html',
       mime: 'text/html',


### PR DESCRIPTION
Apache doesn’t compare if the date is after the modification date, it
juste compares if the dates are equal, so it fails when the date is in
the future of the Last-Modified header sent in the response.

Rename the option to match the name of the header (lastCheckedAt ->
lastModified).