### PR TITLE
Add unchanged property instead of overriding type

### DIFF
--- a/lib/path/analyzers/file.js
+++ b/lib/path/analyzers/file.js
@@ -22,7 +22,7 @@ async function analyzeFile(token, options) {
     token.digest = `${options.digestAlgorithm}-${digest}`
 
     if (options.cache && options.cache.getFileCache && await options.cache.getFileCache(token, options)) {
-      token.type = 'unchanged'
+      token.unchanged = true
       token.analyzed = true
     }
   }

--- a/lib/url/analyzers/file.js
+++ b/lib/url/analyzers/file.js
@@ -21,7 +21,7 @@ async function analyzeBody(token, options) {
     token.path = filePath
 
     if (options.cache && options.cache.getFileCache && await options.cache.getFileCache(token, options)) {
-      token.type = 'unchanged'
+      token.unchanged = true
       token.analyzed = true
     }
   } catch (err) {

--- a/lib/url/fetch.js
+++ b/lib/url/fetch.js
@@ -66,7 +66,7 @@ async function fetch(token, options) {
       throw new Error('There was no body in the response')
 
     case 304:
-      token.type = 'unchanged'
+      token.unchanged = true
       token.analyzed = true
       break
 

--- a/tests/path/analyzers/file.test.js
+++ b/tests/path/analyzers/file.test.js
@@ -107,6 +107,7 @@ test('should mark the file as unchanged if the cache is matched', async t => {
     }
   })
 
-  t.is(token.type, 'unchanged')
+  t.is(token.type, 'file')
+  t.true(token.unchanged)
   t.true(token.analyzed)
 })

--- a/tests/url/fetch.test.js
+++ b/tests/url/fetch.test.js
@@ -106,7 +106,7 @@ test('should error if request has no body', async t => {
   return t.throws(fetch(token, options), 'There was no body in the response')
 })
 
-test('should set the unchanged type for HTTP 304', async t => {
+test('should set the unchanged property for HTTP 304', async t => {
   const location = await serveEmpty(304)
   const token = {url: location}
 
@@ -114,8 +114,8 @@ test('should set the unchanged type for HTTP 304', async t => {
 
   t.deepEqual(token, {
     analyzed: true,
+    unchanged: true,
     statusCode: 304,
-    type: 'unchanged',
     url: location,
     finalUrl: location,
     redirectUrls: []


### PR DESCRIPTION
For cached HTTP requests, type will remain undefined, because no node type has been extracted and `unchanged` is set to `true`.
For files, type remains `file` and `unchanged` is `true`.

---

Slightly breaking, but no big deal, no need for a major release.