### PR TITLE
Stop sharing temporary directories for index-of

### DIFF
--- a/lib/url/analyzers/index-of.js
+++ b/lib/url/analyzers/index-of.js
@@ -6,7 +6,6 @@ const {pipe} = require('mississippi')
 const htmlparser = require('htmlparser2')
 const normalize = require('normalize-url')
 
-const {createTempDirectory} = require('../../util/tmpdir')
 const bufferize = require('../bufferize')
 
 function stripQuery(location) {
@@ -84,12 +83,9 @@ async function analyzeIndexOf(token, options) {
     token.children = []
 
     if (links.length > 0) {
-      const temporary = await createTempDirectory()
-
       token.children = links.map(url => ({
         inputType: 'url',
-        url,
-        temporary
+        url
       }))
     }
   }

--- a/tests/url/analyzers/index-of.test.js
+++ b/tests/url/analyzers/index-of.test.js
@@ -4,7 +4,6 @@ const analyzeIndexOf = require('../../../lib/url/analyzers/index-of')
 const fetch = require('../../../lib/url/fetch')
 
 const {serveFile} = require('../../__helpers__/server')
-const rm = require('../../__helpers__/rm')
 
 const options = {
   userAgent: 'plunger/test',
@@ -52,8 +51,6 @@ test('should analyze content as an index of page', async t => {
 
   t.true(token.analyzed)
   t.is(token.type, 'index-of')
-
-  return rm(token.children[0].temporary)
 })
 
 test('should not analyze as index of if no indexOfMatches are specified', async t => {
@@ -156,20 +153,14 @@ test('should return an array of children', async t => {
   await fetch(token, options)
   await analyzeIndexOf(token, options)
 
-  const [{temporary}] = token.children
-
   t.deepEqual(token.children, [
     {
       inputType: 'url',
-      temporary,
       url: `${url}/file.txt`
     },
     {
       inputType: 'url',
-      temporary,
       url: `${url}/file.zip`
     }
   ])
-
-  return rm(temporary)
 })

--- a/tests/url/index.test.js
+++ b/tests/url/index.test.js
@@ -36,19 +36,15 @@ test('should analyze an index-of completely', async t => {
 
   await analyzeUrl(token, options)
 
-  const [{temporary}] = token.children
-
   t.deepEqual(token, {
     analyzed: true,
     children: [
       {
         inputType: 'url',
-        temporary,
         url: `${url}/file.txt`
       },
       {
         inputType: 'url',
-        temporary,
         url: `${url}/file.zip`
       }
     ],
@@ -66,8 +62,6 @@ test('should analyze an index-of completely', async t => {
     type: 'index-of',
     url
   })
-
-  return rm(temporary)
 })
 
 test('should allow overriding fetch options with cache.getUrlCache', async t => {


### PR DESCRIPTION
This would cause files to be overridden when zip would be extracted in the same directory.